### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a problem with the bot
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Filling in as much as you can makes it
+        far quicker to diagnose. **Redact every secret** (bot token, provider API keys, admin
+        IDs) from logs and screenshots before posting.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: dropdown
+    id: providers
+    attributes:
+      label: Affected provider(s)
+      multiple: true
+      options:
+        - Vultr
+        - Hetzner
+        - AWS
+        - Not provider-specific
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / runtime
+      placeholder: "e.g. Ubuntu 24.04, Windows Server 2022, Docker"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.12.4"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant output from `logs/`. Redact tokens, keys, and IDs first.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I removed all secrets (bot token, API keys, admin IDs) from logs and screenshots.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/kirillDevPro/cloud-control-bot/security/policy
+    about: Please report security issues privately — see SECURITY.md. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what are you trying to do?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've thought about.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — screenshots, links, related providers.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] Other:
+
+## Checklist
+
+- [ ] `ruff check src main.py scripts/check_i18n_locales.py` passes
+- [ ] `mypy src main.py scripts/check_i18n_locales.py` passes
+- [ ] `python scripts/check_i18n_locales.py` passes (run if any UI string changed)
+- [ ] New/changed UI strings were added to **every** locale (`en`, `ru`, `uk`, `es`)
+- [ ] Code, docstrings, and comments are in English
+- [ ] Commit messages follow the `type(scope): subject` convention


### PR DESCRIPTION
Adds GitHub issue forms (bug report + feature request), an issue-template config that routes security reports to the private channel (SECURITY.md) and disables blank issues, and a pull request template whose checklist mirrors the three CI checks and the every-locale i18n rule.